### PR TITLE
Relationship model names and allow generation of relationships without instances

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "wakes/silverstripe-fixturegenerator",
+    "name": "camspiers/silverstripe-fixturegenerator",
     "description": "Allows the generation of SilverStripe unit test fixtures from existing DataObjects either programatically created or from the database",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "camspiers/silverstripe-fixturegenerator",
+    "name": "wakes/silverstripe-fixturegenerator",
     "description": "Allows the generation of SilverStripe unit test fixtures from existing DataObjects either programatically created or from the database",
     "license": "MIT",
     "authors": [

--- a/src/Camspiers/SilverStripe/FixtureGenerator/Generator.php
+++ b/src/Camspiers/SilverStripe/FixtureGenerator/Generator.php
@@ -90,10 +90,10 @@ class Generator
 
                     // Only process it if it exists
                     if ($hasOne->exists() && !$this->hasDataObject($hasOne, $map)) {
-	                    if (($this->mode & self::RELATED_OBJECT_EXCLUDE) === 0) {
-		                    // Recursively generate a map for this object
-	                        $this->generateFromDataObject($hasOne, $map);
-	                    }
+                        if (($this->mode & self::RELATED_OBJECT_EXCLUDE) === 0) {
+                            // Recursively generate a map for this object
+                            $this->generateFromDataObject($hasOne, $map);
+                        }
                         // Add the relation to the current dataobjects map
                         $map[$className][$id][$relName] = "=>$relClassName." . $hasOne->ID;
                     }
@@ -115,10 +115,10 @@ class Generator
 
                             // Only process it if it exists
                             if ($hasMany->exists() && !$this->hasDataObject($hasMany, $map)) {
-	                            if (($this->mode & self::RELATED_OBJECT_EXCLUDE) === 0) {
+                                if (($this->mode & self::RELATED_OBJECT_EXCLUDE) === 0) {
                                     // Recursively generate a map for this object
-	                                $this->generateFromDataObject($hasMany, $map);
-	                            }
+                                    $this->generateFromDataObject($hasMany, $map);
+                                }
                                 // Add the relation to the original objects map
                                 if (!isset($map[$className][$id][$relName])) {
                                     $map[$className][$id] = array_merge(
@@ -151,10 +151,10 @@ class Generator
 	                        $relClassName = $manyMany->ClassName;
 
                             if ($manyMany->exists() && !$this->hasDataObject($manyMany, $map)) {
-	                            if (($this->mode & self::RELATED_OBJECT_EXCLUDE) === 0) {
-		                            // Recursively generate a map for this object
-	                                $this->generateFromDataObject($manyMany, $map);
-	                            }
+                                if (($this->mode & self::RELATED_OBJECT_EXCLUDE) === 0) {
+                                    // Recursively generate a map for this object
+                                    $this->generateFromDataObject($manyMany, $map);
+                                }
                                 // Add the relation to the original objects map
                                 if (!isset($map[$className][$id][$relName])) {
                                     $map[$className][$id] = array_merge(

--- a/src/Camspiers/SilverStripe/FixtureGenerator/Generator.php
+++ b/src/Camspiers/SilverStripe/FixtureGenerator/Generator.php
@@ -19,10 +19,10 @@ class Generator
      * This mode excludes relations specified
      */
     const RELATION_MODE_EXCLUDE = 1;
-	/**
-	 * This mode excludes generation of related objects (however relationships may still be generated)
-	 */
-	const RELATED_OBJECT_EXCLUDE = 2;
+    /**
+     * This mode excludes generation of related objects (however relationships may still be generated)
+     */
+    const RELATED_OBJECT_EXCLUDE = 2;
     /**
      * @var DumperInterface
      */
@@ -86,7 +86,7 @@ class Generator
                     // Get the dataobject from the relation
                     $hasOne = $dataObject->$relName();
 
-	                $relClassName = $hasOne->ClassName;
+                    $relClassName = $hasOne->ClassName;
 
                     // Only process it if it exists
                     if ($hasOne->exists() && !$this->hasDataObject($hasOne, $map)) {
@@ -111,7 +111,7 @@ class Generator
                         // Loops of each dataobject
                         foreach ($items as $hasMany) {
 
-	                        $relClassName = $hasMany->ClassName;
+                            $relClassName = $hasMany->ClassName;
 
                             // Only process it if it exists
                             if ($hasMany->exists() && !$this->hasDataObject($hasMany, $map)) {
@@ -148,7 +148,7 @@ class Generator
                         foreach ($items as $manyMany) {
                             // Only process it if it exists
 
-	                        $relClassName = $manyMany->ClassName;
+                            $relClassName = $manyMany->ClassName;
 
                             if ($manyMany->exists() && !$this->hasDataObject($manyMany, $map)) {
                                 if (($this->mode & self::RELATED_OBJECT_EXCLUDE) === 0) {


### PR DESCRIPTION
Hi,

My first pull request ever so apologies me if I'm doing it wrong!

I've updated to allow relationship names to reflect the actual class of the foreign key object in the case of the instance being derived from the model in the relationship instead of being of that class.

Also found it usefull to be able to generate the relationships without the actual foreign key objects in the case of having to do a big cut-and-paste job so have added a mode 'RELATED_OBJECT_EXCLUDE' to allow this.

Cheers,
Steve
